### PR TITLE
fix: 为 session.get() 添加MiMoCode兼容性

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -431,7 +431,9 @@ function TokenCachePanel(props: {
 
     // 自然追踪 messages 和 provider（SDK 数据就绪时自动重新执行）
     const msgs = props.api.state.session.messages(sid) as Message[]
-    const session = props.api.state.session.get(sid)
+    const session = typeof props.api.state.session.get === "function"
+      ? props.api.state.session.get(sid)
+      : undefined
 
     // 累计值优先使用 Session 聚合字段（数据库级，不受 sync 层 limit:100 截断）
     // 若字段不存在（旧版本 SDK），降级到消息遍历累加


### PR DESCRIPTION
## 摘要

修复 opencode-visual-cache 插件在 MiMoCode TUI 中的 session.get() 兼容性问题。

## 问题

MiMoCode 的 TUI Plugin API 中没有 session.get() 方法，导致插件在 src/index.tsx:434 处崩溃。当前 MiMoCode 的 session API 提供 messages()、status()、goal()、cwd()、count()、diff()、todo()、task()、permission()、question() 等方法，但没有 get() 这一便利方法。

## 改动

对 session.get() 调用c——调用前检查方法是否存在，不存在时降级为 undefined。插件在第 438-459 行已通过 ?? 默认值优雅处理 null/undefined 的 session 值，无需额外修改。

## 兼容性

- OpenCode：get() 存在时行为不变
- MiMoCode：自动降级到基于消息的备选方案（插件内部已实现）