### PR TITLE
fix(plugin): 拆分 server/tui 入口兼容 OpenCode v1 插件规范

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,11 @@
   "version": "1.2.15",
   "description": "OpenCode TUI plugin displaying real-time token cache hit rate in the sidebar",
   "type": "module",
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+    "./server": {
+      "import": "./dist/server.js",
+      "types": "./dist/server.d.ts"
     },
     "./tui": {
       "import": "./dist/tui.js",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,10 @@
+import type { Plugin, PluginModule } from "@opencode-ai/plugin"
+
+const server: Plugin = async () => ({})
+
+const mod: PluginModule = {
+  id: "opencode-visual-cache",
+  server,
+}
+
+export default mod


### PR DESCRIPTION
## 问题

经 `Ctrl+P → install plugin` 安装本插件后，部分用户遇到 OpenCode 启动报错并退出：

```
Plugin opencode-visual-cache must default export an object with server()
```

## 根因

`Ctrl+P → install plugin` 会根据 `package.json` 的 `exports` 和 `main` 字段判定插件具备哪些 target（`install.ts` 的 `packageTargets`）：

- `exports["./server"]` 不存在，但 `main` 存在 → 推入 `{ kind: "server" }`
- `exports["./tui"]` 存在 → 推入 `{ kind: "tui" }`

因此插件被同时写入 `opencode.json`（server 通道）和 `tui.json`（TUI 通道）。

本插件是纯 TUI 插件，`dist/index.js`（`main` 指向的文件）只导出 `{ id, tui }`，没有 `server` 键。OpenCode v1 加载器 `readV1Plugin` 以 `kind=server` 解析该模块时，因 `server` 键为 `undefined` 而抛错。

TUI 通道从 `exports["./tui"]` 加载 `dist/tui.js`，始终正常——所以 TUI 功能能显示，server 通道的报错在某些 OpenCode 版本下被吞为日志，在另一些版本下直接导致退出。

## 修复方式

按 OpenCode v1 规范，`./server` 和 `./tui` 应为分离的 target-only 模块，互斥导出（`PluginModule.tui` 为 `never`）。

- **删除 `main` 字段**，移除 `exports["."]` 通用入口——切断 server 通道对 TUI 模块的 fallback 解析路径。
- **新增 `exports["./server"]`** 指向 `dist/server.js`，导出空 server（`{ id, server: async () => ({}) }`）——server 通道加载到合法的 `PluginModule`，不注册任何 hook，完全静默。
- **新增 `src/server.ts`** 作为空 server 入口源文件。
- TUI 功能仍由 `./tui` 入口承载，不受影响。

## 生效机制

```
opencode.json (server 通道) → exports[./server] → dist/server.js → { id, server } → 校验通过，空 server 静默运行
tui.json    (TUI 通道)    → exports[./tui]    → dist/tui.js    → { id, tui }    → 侧边栏正常
```

两个通道各取各的入口，互不干扰。`Ctrl+P → install plugin` 同时写两个文件都不出问题。