### PR TITLE
fix: 透传 session_prompt_right 插槽，修复对 oc-tps 等提示区插件的遮挡

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1578,6 +1578,9 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
             onSubmit={input.on_submit}
             ref={input.ref}
             hint={<BottomStatusBar api={api} signals={signals} sessionId={input.session_id} />}
+            // 接管 session_prompt 后需透传宿主的 session_prompt_right 插槽，
+            // 否则 oc-tps 等依赖该插槽的插件无法显示；无注册时 Slot 为 null。
+            right={<api.ui.Slot name="session_prompt_right" session_id={input.session_id} />}
           />
         )
       },


### PR DESCRIPTION
## 问题

本插件以 `replace` 模式接管 `session_prompt` 插槽后，宿主默认的 `Prompt` 组件（连同其内部的 `session_prompt_right` 插槽渲染点）被整体替换，且未透传 `right` prop。

结果是任何依赖 `session_prompt_right` 插槽的第三方 TUI 插件（如 [oc-tps](https://github.com/Tarquinen/oc-tps) 的 TPS/AVG/TTFT 显示）在安装本插件后完全无法渲染——两个插件看似冲突，实为本插件吞掉了渲染点。

## 修复

与宿主默认路由（`packages/tui/src/routes/session/index.tsx`）保持一致，向 `api.ui.Prompt` 透传 `right` prop：

```tsx
right={<api.ui.Slot name="session_prompt_right" session_id={input.session_id} />}
```

- 有插件注册 `session_prompt_right` 时正常渲染在其惯常位置（输入框右侧）
- 无插件注册该插槽时 `Slot` 渲染为 `null`，行为与原先不传 `right` 完全一致，零副作用

## 验证

- `tsc --noEmit` 通过，构建产物 diff 仅为该 3 行修复
- OpenCode 1.18.18 实机（tmux）验证：同时安装 oc-tps + opencode-visual-cache，输入行实测渲染出 `TPS - | AVG 31.9 | TTFT 6.9s`（oc-tps）与底部命中率状态栏（本插件）共存
- 未安装 oc-tps 时回归验证：显示与修复前无差异

## 效果对比

修复前：输入行右侧无 TPS 显示（渲染点被本插件接管后丢失）

修复后（宽终端）：
```
Sisyphus - Ultraworker · glm-5.3 · max    TPS - | AVG 31.9 | TTFT 6.9s    ~/projects/...
~/projects/...    命中率 34.1% · Tokens 129.1K (13%)    ctrl+p commands
```
