### PR TITLE
fix(v2): 底部状态栏显隐开关 + oc2 发布 server 入口

### DIFF
--- a/scripts/prepare-v2-publish.mjs
+++ b/scripts/prepare-v2-publish.mjs
@@ -2,9 +2,9 @@
 // 用法: node scripts/prepare-v2-publish.mjs <version>
 // 改写 package.json 为 v2 (oc2) 版本：
 //   - version = 指定版本（如 1.7.0-oc2）
-//   - exports["./server"] → ./dist/v2.js（V2 加载器实测只认 ./server——无它会被静默跳过；
-//     v2.js 是纯 {id, setup}，无 server 字段，不会触发 V1 路径）
-//   - main/exports["."] 同样指向 v2.js（备用）
+//   - exports["./server"] → ./dist/server.js（V1 空实现；V2 server 端加载它不会触发
+//     TUI 代码——v2.js 的 setup 访问 context.renderer，server context 无该字段会崩溃）
+//   - main/exports["."] 指向 v2.js（备用）
 //   - peerDependencies 替换为 v2.js 实际运行时依赖（build.tui.mjs external: @opentui/*、solid-js）
 // 其余字段（scripts/files/bin 等）原样保留。发布后由 git checkout HEAD -- package.json 恢复。
 import { readFileSync, writeFileSync } from "fs"
@@ -19,10 +19,10 @@ const pkg = JSON.parse(readFileSync("package.json", "utf8"))
 pkg.version = version
 pkg.main = "./dist/v2.js"
 // V2 加载确认（2026-08-17）：exports["./tui"] → tui/index.js 是 npm 包名方式可行的关键
-//（V2 认 ./tui 作为 TUI 入口）；"."/"./server" 指向 v2.js 会 Invalid（import.meta.resolve 缺陷）。
+//（V2 认 ./tui 作为 TUI 入口）；"." 指向 v2.js 会 Invalid（import.meta.resolve 缺陷）。
 pkg.exports = {
   ".": "./dist/v2.js",
-  "./server": "./dist/v2.js",
+  "./server": "./dist/server.js",
   "./tui": "./tui/index.js",
 }
 // 发布必须含 tui/index.js（V2 目录加载入口——resolveLocal 对目录解析 dir/tui）

--- a/src/v2/index.tsx
+++ b/src/v2/index.tsx
@@ -172,7 +172,7 @@ const mod: PluginModule & { server: () => Promise<Record<string, never>> } = {
     context.ui.slot({
       append: "prompt.footer.status",
       render: (props) => (
-        <StatusView context={context} signals={signals} sessionID={String(props.sessionID ?? "")} />
+        <StatusView context={context} api={api} signals={signals} sessionID={String(props.sessionID ?? "")} />
       ),
     })
 

--- a/src/v2/status.tsx
+++ b/src/v2/status.tsx
@@ -99,7 +99,7 @@ export function StatusView(props: {
   })
 
   return (
-    <Show when={segsW() > 0 && props.signals.sectionBottom()}>
+    <Show when={segsW() > 0 && stats().hitRate >= 0 && props.signals.sectionBottom()}>
       <text>
         <For each={segs()}>{(sg) => <span style={{ fg: sg.color }}>{sg.text}</span>}</For>
       </text>

--- a/src/v2/status.tsx
+++ b/src/v2/status.tsx
@@ -1,25 +1,37 @@
 /** @jsxImportSource @opentui/solid */
 
-import { createMemo, For, Show } from "solid-js"
+import { createMemo, For, onMount, Show } from "solid-js"
 import type { Context } from "./types"
-import type { PanelSignals } from "../panel/panel-api"
+import type { PanelApi, PanelSignals } from "../panel/panel-api"
 import { collectLastHitRate } from "./data"
 import { desaturateTo, fmtCompact, formatBalanceText, MAX_SAT, FALLBACK, visualWidth } from "../core"
 import { createT } from "../i18n"
 import { mapTheme } from "./theme"
+
+const KV_PREFIX = "cache_panel"
 
 /**
  * 底部状态栏（prompt.footer.status）——对齐 V1 BottomStatusBar 统计段口径：
  * 单条命中率（最后一条有 token 的 assistant 消息）+ 趋势 + Tokens 总量 + 余额。
  * 余额读共享 signals.balanceState（PluginRoot 驱动轮询）；provider 不支持余额时隐藏余额段（对齐 V1）。
  * 颜色经 mapTheme（V1 形状）——与侧边栏命中率颜色同源，保证两处一致。
+ * 显隐受 signals.sectionBottom 控制（/cache-section 切换），启动时从 kv 恢复偏好（对齐 V1）。
  */
 export function StatusView(props: {
   context: Context
+  api: PanelApi
   signals: PanelSignals
   sessionID: string
 }) {
   const t = createT(() => props.signals.langCode())
+
+  // 恢复显隐偏好（默认显示；关闭时隐藏统计段，与宿主默认 hint 行一致）
+  onMount(() => {
+    try {
+      const v = props.api.kv.get<boolean>(`${KV_PREFIX}.section.bottom`, true)
+      props.signals.setSectionBottom(v !== false)
+    } catch {}
+  })
 
   // 与侧边栏 TokenCachePanel 同一颜色来源（mapTheme → desaturateTo）
   const pal = createMemo(() => {
@@ -87,7 +99,7 @@ export function StatusView(props: {
   })
 
   return (
-    <Show when={segsW() > 0}>
+    <Show when={segsW() > 0 && props.signals.sectionBottom()}>
       <text>
         <For each={segs()}>{(sg) => <span style={{ fg: sg.color }}>{sg.text}</span>}</For>
       </text>


### PR DESCRIPTION
## 修复

1. 底部状态栏显隐：`StatusView` 按 `sectionBottom` 控制 + 启动恢复 kv 偏好（对齐 V1 `BottomStatusBar`）
2. server 入口：`prepare-v2-publish.mjs` 的 `exports["./server"]` 改回 `dist/server.js` 空实现，避免 server 端加载 TUI 代码崩溃
3. 空会话守卫：无有效 assistant token 数据时隐藏状态栏，避免显示占位统计

## 验证

- `npm run typecheck` / `npm run build` 通过
- 本地 opencode2（beta-18743）实测：bottom 可关闭、Server 段不再 `failed`、空会话不显示状态栏